### PR TITLE
Entropy check for Growth draw

### DIFF
--- a/growth/entropy
+++ b/growth/entropy
@@ -1,3 +1,3 @@
-# We will use the hash of block 17034520 as a random seed
+# We will use the hash of block 17034520 as a random seed 
 
 0xf4c8050e17bd54c4d7ba887dee982e67bab0d3c9dfaf997ef8e794758485fea3


### PR DESCRIPTION
Despite GitHub settings requiring a PR to merge to `main`, I was able to push to it without warning (probably because I can bypass protections in this repo).

This PR is therefore purely to get a second set of eyes on the entropy for the Growth draw.