### PR TITLE
add hash for e30d draw

### DIFF
--- a/every-30-days/entropy
+++ b/every-30-days/entropy
@@ -1,3 +1,5 @@
 # We will use the hash of block 18243383 as a random seed
 
 # https://etherscan.io/block/18243383
+
+0xe482442fa7f2249d8a7c15e66f19028ed83f3c6a4188b1a9c2836c39237f034d

--- a/raffle.sh
+++ b/raffle.sh
@@ -79,6 +79,4 @@ draw grails/season-03-deafbeef-physical/copperSwirl 1
 draw grails/season-03-deafbeef-physical/copper3 1
 draw grails/season-03-deafbeef-physical/gold 1
 
-draw every-30-days/participants 1
-draw every-30-days/participants 2
-draw every-30-days/participants 1
+draw every-30-days/participants 3

--- a/raffle.sh
+++ b/raffle.sh
@@ -81,3 +81,4 @@ draw grails/season-03-deafbeef-physical/gold 1
 
 draw every-30-days/participants 1
 draw every-30-days/participants 2
+draw every-30-days/participants 1


### PR DESCRIPTION
There is one grand prize winner and 2 runner ups. I initially did:
```
draw 1
draw 2
```

At first I thought it was just luck, and was going to do another `draw 1`, until I realized the first result in the draw 2 is also the winner from draw 1 (and that it wasn't luck).

<img width="848" alt="Screenshot 2023-09-29 at 12 29 09 PM" src="https://github.com/proofxyz/raffles/assets/1627900/f57807f9-d908-4fa7-acff-49ee88654d64">

In order to correctly draw three winners, I'd have to `draw 3`. Luckily, the results are always the same, so the first two winners of the draw three are also the same as the winners from `draw 2` (and `draw 1`)